### PR TITLE
Disable TCP SACK

### DIFF
--- a/sysctls/50-net.conf
+++ b/sysctls/50-net.conf
@@ -1,3 +1,7 @@
 net.core.bpf_jit_harden = 2
 
 net.netfilter.nf_conntrack_udp_timeout_stream = 360
+
+net.ipv4.tcp_sack=0
+net.ipv4.tcp_dsack=0
+net.ipv4.tcp_fack=0


### PR DESCRIPTION
This disables TCP SACK, DSACK and FACK. SACK is commonly exploited (for example: https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-001.md) and not needed for many people.

Although, disabling SACK can cause significant connectivity issues for some.